### PR TITLE
Resolve Grid Layout Persistence on Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to the YouTube Dynamic Video Grid project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2025-05-13
+
+### Added
+
+- Handling for `elements-per-row` attribute to align with YouTube's Polymer bindings
+- Normalized margins for first-column items (`[is-in-first-column]`) to 8px
+- Vertical spacing with 16px bottom margin and 10px gap
+- Content Security Policy (CSP) compliance using `<style>` element with nonce
+- Single-page application (SPA) navigation support via URL monitoring and `popstate` events
+- Production-ready comments for maintainability
+
+### Changed
+
+- Updated grid calculation parameters: `videoWidth=340px`, `margin=40px`, `gap=10px`
+- Switched to `Math.round` for item calculation to balance item count and space usage
+- Optimized polling: 200ms for 5 seconds (early), 1000ms for 25 seconds (regular), with early termination after 5 stable checks
+- Increased initial retries to 20 at 100ms intervals for faster grid detection
+- Added debouncing (50ms) for grid updates and throttling (100ms) for resize events
+- Changed execution timing to `document-end` for earlier grid styling
+- Improved observer to monitor `#contents`, `ytd-two-column-browse-results-renderer`, or `ytd-app` with specific attributes (`style`, `class`, `hidden`, `elements-per-row`)
+
+### Fixed
+
+- Grid reverting to 3 items on Subscriptions tab
+- Flicker during initial grid load
+- Uneven first-column margins causing layout inconsistencies
+
+## [1.0.0] - 2024-04-25
+
+### Added
+
+- Initial release of YouTube Dynamic Video Grid
+- Dynamic adjustment of `ytd-rich-grid-renderer` to set `--ytd-rich-grid-items-per-row` and `--ytd-rich-grid-posts-per-row` based on window width
+- Support for 3 to 12 items per row, calculated using `videoWidth=340px`, `margin=32px`, `gap=16px`
+- MutationObserver on `#primary` or `document.body` to detect grid changes
+- Polling every 250ms for 10 seconds to ensure initial grid load
+- Event listeners for window `resize` and `load` events

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This is a script that I use personally, so your mileage may vary; however, you s
    - Visit [YouTube](https://www.youtube.com/) in your browser.
    - The script will automatically adjust the video grid based on your window size.
    - Resize your browser window to see the grid dynamically adapt.
+   - Enable debug logging by appending `?debug=1` to the URL (e.g., `https://www.youtube.com/?debug=1`).
 
 ## Features
 
@@ -49,6 +50,16 @@ This is a script that I use personally, so your mileage may vary; however, you s
 - The script runs automatically on YouTube pages (`*://www.youtube.com/*` and `*://youtube.com/*`).
 - No configuration is required; the grid adjusts based on your browser window's width.
 - For optimal performance, avoid running multiple grid-modifying scripts simultaneously.
+
+## Parameters
+
+- `videoWidth`: 340px (thumbnail width, tuned for ~9 items on 3440x1440)
+- `margin`: 40px (total left/right margins)
+- `gap`: 10px (spacing between thumbnails)
+
+## Limitations
+
+May require parameter adjustments for different monitor sizes. File issues at [support](https://github.com/nicholas-fedor/youtube-dynamic-grid/issues).
 
 ## Contributing
 

--- a/youtube-dynamic-grid.user.js
+++ b/youtube-dynamic-grid.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         YouTube Dynamic Video Grid
 // @namespace    https://github.com/nicholas-fedor/youtube-dynamic-grid
-// @version      1.0.0
-// @description  Dynamically adjusts the YouTube video grid to display an optimal number of videos per row based on window width, overriding the default 3-video grid for a more responsive layout.
+// @version      1.0.1
+// @description  Dynamically adjusts the YouTube video grid to display an optimal number of videos per row based on window width, overriding the default 3-video grid for a more responsive layout
 // @author       Nick Fedor
 // @match        *://www.youtube.com/*
 // @match        *://youtube.com/*
@@ -13,72 +13,375 @@
 // @downloadURL  https://github.com/nicholas-fedor/youtube-dynamic-grid/raw/main/youtube-dynamic-grid.user.js
 // @license      MIT
 // @grant        none
-// @run-at       document-idle
+// @run-at       document-end
 // ==/UserScript==
 
 (function () {
   'use strict';
 
-  function updateGrid() {
-    const grid = document.querySelector('ytd-rich-grid-renderer');
-    if (grid) {
-      const width = window.innerWidth; // Approximate grid width
-      const videoWidth = 340; // Calculated for 6 videos at ~2,150px
-      const margin = 32; // Page margins
-      const gap = 16; // Gap between videos
-      let itemsPerRow = Math.floor((width - margin) / (videoWidth + gap));
-      itemsPerRow = Math.max(3, Math.min(12, itemsPerRow)); // Cap between 3 and 12
-      grid.style.setProperty(
-        '--ytd-rich-grid-items-per-row',
-        itemsPerRow,
-        'important'
-      );
-      grid.style.setProperty(
-        '--ytd-rich-grid-posts-per-row',
-        itemsPerRow,
-        'important'
-      );
+  /**
+   * Logs messages to the console for debugging when enabled via ?debug=1 query parameter
+   * @param {string} message - Message to log
+   * @param {boolean} [force=false] - Forces logging regardless of debug mode
+   */
+  function log(message, force = false) {
+    if (force || window.location.search.includes('debug=1')) {
+      console.log(`[YouTube Dynamic Grid] ${message}`);
     }
   }
 
-  // Initial update with retry mechanism
-  function tryUpdateGrid(attempts = 5, interval = 500) {
+  /**
+   * Calculates the number of items per row based on the container width
+   * @returns {number} Number of items per row, capped between 3 and 12
+   */
+  function calculateItemsPerRow() {
+    // Select the grid container or fallback to document.body
+    const container =
+      document.querySelector('#contents') ||
+      document.querySelector('ytd-two-column-browse-results-renderer') ||
+      document.body;
+    const width = container.getBoundingClientRect().width || window.innerWidth;
+    const videoWidth = 340; // Estimated thumbnail width in pixels
+    const margin = 40; // Total left and right margins in pixels
+    const gap = 10; // Gap between thumbnails in pixels
+    const firstColumnExtraMargin = 0; // Normalized by CSS, no extra margin
+    // Round to nearest integer to balance item count and space usage
+    let itemsPerRow = Math.round(
+      (width - margin - firstColumnExtraMargin) / (videoWidth + gap)
+    );
+    // Cap items between 3 and 12 for layout consistency
+    return Math.max(3, Math.min(12, itemsPerRow));
+  }
+
+  /**
+   * Updates the grid's elements-per-row attribute and CSS styles with debouncing
+   */
+  let updateTimeout = null;
+  function updateGrid() {
+    clearTimeout(updateTimeout);
+    updateTimeout = setTimeout(() => {
+      try {
+        const grid = document.querySelector(
+          'ytd-rich-grid-renderer:not([hidden])'
+        );
+        if (grid) {
+          const width =
+            document.querySelector('#contents')?.getBoundingClientRect()
+              .width || window.innerWidth;
+          const itemsPerRow = calculateItemsPerRow();
+          const currentItems = getComputedStyle(grid)
+            .getPropertyValue('--ytd-rich-grid-items-per-row')
+            .trim();
+          const currentAttr =
+            grid.getAttribute('elements-per-row') || 'unknown';
+          // Update only if item count or attribute differs
+          if (
+            currentItems !== String(itemsPerRow) ||
+            currentAttr !== String(itemsPerRow)
+          ) {
+            // Set Polymer attribute to align with CSS
+            grid.setAttribute('elements-per-row', itemsPerRow);
+            updateCSS(itemsPerRow);
+            log(
+              `Updated items per row to ${itemsPerRow} (was ${currentItems}, attr ${currentAttr}) for width ${width}px`,
+              true
+            );
+          }
+        } else {
+          log('No visible grid found');
+        }
+      } catch (error) {
+        log(`Error updating grid: ${error.message}`);
+      }
+    }, 50); // Debounce updates by 50ms to prevent rapid calls
+  }
+
+  /**
+   * Injects a dynamic CSS style element to override grid layout
+   */
+  function injectCSS() {
+    let style = document.getElementById('dynamic-grid-style');
+    if (!style) {
+      style = document.createElement('style');
+      style.id = 'dynamic-grid-style';
+      // Apply CSP nonce if available to comply with YouTube's security policy
+      const nonce = document.querySelector('meta[name="csp-nonce"]')?.content;
+      if (nonce) style.nonce = nonce;
+      document.head.appendChild(style);
+      log('Injected dynamic CSS rule with nonce', true);
+      const itemsPerRow = calculateItemsPerRow();
+      style.textContent = `
+        #contents, ytd-two-column-browse-results-renderer {
+          max-width: 100% !important;
+          width: 100% !important;
+          padding: 0 !important;
+        }
+        ytd-rich-grid-renderer {
+          --ytd-rich-grid-items-per-row: ${itemsPerRow} !important;
+          --ytd-rich-grid-posts-per-row: ${itemsPerRow} !important;
+          max-width: 100% !important;
+          padding: 0 !important;
+          gap: 10px !important; /* Consistent horizontal and vertical spacing */
+        }
+        ytd-rich-grid-renderer [is-in-first-column] {
+          margin-left: 8px !important;
+          margin-right: 8px !important;
+          margin-bottom: 16px !important; /* Vertical spacing for first-column items */
+        }
+        ytd-rich-item-renderer {
+          margin: 0 8px 16px 8px !important; /* Uniform margins with vertical spacing */
+        }
+      `;
+    }
+  }
+
+  /**
+   * Updates the dynamic CSS rule with the specified number of items per row
+   * @param {number} itemsPerRow - Number of items per row
+   */
+  function updateCSS(itemsPerRow) {
+    const style = document.getElementById('dynamic-grid-style');
+    style.textContent = `
+      #contents, ytd-two-column-browse-results-renderer {
+        max-width: 100% !important;
+        width: 100% !important;
+        padding: 0 !important;
+      }
+      ytd-rich-grid-renderer:not([hidden]) {
+        --ytd-rich-grid-items-per-row: ${itemsPerRow} !important;
+        --ytd-rich-grid-posts-per-row: ${itemsPerRow} !important;
+        max-width: 100% !important;
+        padding: 0 !important;
+        gap: 10px !important;
+      }
+      ytd-rich-grid-renderer:not([hidden]) [is-in-first-column] {
+        margin-left: 8px !important;
+        margin-right: 8px !important;
+        margin-bottom: 16px !important;
+      }
+      ytd-rich-grid-renderer:not([hidden]) ytd-rich-item-renderer {
+        margin: 0 8px 16px 8px !important;
+      }
+    `;
+  }
+
+  /**
+   * Attempts to update the grid with retries until the grid is visible
+   * @param {number} [attempts=20] - Number of retry attempts
+   * @param {number} [interval=100] - Retry interval in milliseconds
+   */
+  function tryUpdateGrid(attempts = 20, interval = 100) {
     updateGrid();
-    if (attempts > 0 && !document.querySelector('ytd-rich-grid-renderer')) {
+    if (
+      attempts > 0 &&
+      !document.querySelector('ytd-rich-grid-renderer:not([hidden])')
+    ) {
+      log(`Retrying grid update (${attempts} attempts left)`);
       setTimeout(() => tryUpdateGrid(attempts - 1, interval), interval);
     }
   }
-  tryUpdateGrid();
 
-  // Update on window resize
-  window.addEventListener('resize', updateGrid);
-
-  // Update on page load
-  window.addEventListener('load', updateGrid);
-
-  // Observe DOM changes for grid updates
-  const observer = new MutationObserver(updateGrid);
+  /**
+   * Initializes or reinitializes the MutationObserver to monitor grid changes
+   */
+  let observer = null;
   function startObserver() {
-    const target = document.querySelector('#primary') || document.body;
+    if (observer) {
+      observer.disconnect();
+      log('Disconnected previous observer');
+    }
+    observer = new MutationObserver(mutations => {
+      for (const mutation of mutations) {
+        if (
+          mutation.target.matches('ytd-rich-grid-renderer') ||
+          mutation.target.closest('ytd-rich-grid-renderer') ||
+          mutation.target.querySelector('ytd-rich-grid-renderer') ||
+          mutation.attributeName === 'style' ||
+          mutation.attributeName === 'hidden' ||
+          mutation.attributeName === 'class' ||
+          mutation.attributeName === 'elements-per-row' ||
+          mutation.addedNodes.length > 0
+        ) {
+          updateGrid();
+          break; // Exit after first relevant mutation to avoid redundant updates
+        }
+      }
+    });
+    const target =
+      document.querySelector('#contents') ||
+      document.querySelector('ytd-two-column-browse-results-renderer') ||
+      document.querySelector('ytd-app');
     if (target) {
       observer.observe(target, {
         childList: true,
         subtree: true,
+        attributes: true,
+        attributeFilter: ['style', 'class', 'hidden', 'elements-per-row'],
       });
+      log('Started observer on target');
     } else {
-      setTimeout(startObserver, 500); // Retry if target not found
+      log('Target not found, retrying observer');
+      setTimeout(startObserver, 100); // Retry after 100ms if target is missing
     }
   }
-  startObserver();
 
-  // Fallback polling for initial grid load
-  const pollingInterval = setInterval(() => {
-    if (document.querySelector('ytd-rich-grid-renderer')) {
-      updateGrid();
-      clearInterval(pollingInterval); // Stop polling once grid is found
+  /**
+   * Handles navigation events by reinitializing the grid update and observer
+   */
+  let navigationTimeouts = [];
+  function handleNavigation() {
+    navigationTimeouts.forEach(clearTimeout);
+    navigationTimeouts = [];
+    tryUpdateGrid();
+    startObserver();
+    // Schedule delayed updates to catch late renders
+    navigationTimeouts.push(setTimeout(updateGrid, 1000));
+    navigationTimeouts.push(setTimeout(updateGrid, 5000));
+    navigationTimeouts.push(setTimeout(updateGrid, 10000));
+  }
+
+  /**
+   * Monitors SPA navigation via URL changes
+   */
+  let lastUrl = location.href;
+  new MutationObserver(() => {
+    const currentUrl = location.href;
+    if (currentUrl !== lastUrl) {
+      lastUrl = currentUrl;
+      log(`Detected navigation to ${currentUrl}`);
+      handleNavigation();
     }
-  }, 250); // Check every 250ms
+  }).observe(document, { subtree: true, childList: true });
 
-  // Stop polling after 10 seconds to reduce overhead
-  setTimeout(() => clearInterval(pollingInterval), 10000);
+  // Event handlers for cleanup
+  let resizeTimeout = null;
+  const resizeHandler = () => {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(() => {
+      log('Window resized');
+      updateGrid();
+    }, 100); // Throttle resize events by 100ms
+  };
+  const loadHandler = () => {
+    log('Page loaded');
+    handleNavigation();
+  };
+  const popstateHandler = () => {
+    log('Detected popstate navigation');
+    handleNavigation();
+  };
+
+  /**
+   * Polls for grid changes with aggressive early polling to counter style overrides
+   */
+  let pollingInterval = null;
+  let stableCount = 0;
+  function startPolling() {
+    if (pollingInterval) {
+      clearInterval(pollingInterval);
+    }
+    pollingInterval = setInterval(() => {
+      const grid = document.querySelector(
+        'ytd-rich-grid-renderer:not([hidden])'
+      );
+      if (grid) {
+        const currentItems = getComputedStyle(grid)
+          .getPropertyValue('--ytd-rich-grid-items-per-row')
+          .trim();
+        const currentAttr = grid.getAttribute('elements-per-row') || 'unknown';
+        const itemsPerRow = calculateItemsPerRow();
+        if (
+          currentItems !== String(itemsPerRow) ||
+          currentAttr !== String(itemsPerRow)
+        ) {
+          updateGrid();
+          stableCount = 0;
+        } else {
+          stableCount++;
+          if (stableCount >= 5) {
+            clearInterval(pollingInterval);
+            log('Stopped early polling: grid stable');
+            startRegularPolling();
+          }
+        }
+      }
+    }, 200); // Poll every 200ms for first 5 seconds
+    setTimeout(() => {
+      clearInterval(pollingInterval);
+      log('Stopped early polling');
+      startRegularPolling();
+    }, 5000);
+  }
+
+  /**
+   * Continues polling at a slower rate for additional stability
+   */
+  function startRegularPolling() {
+    if (pollingInterval) {
+      clearInterval(pollingInterval);
+    }
+    stableCount = 0;
+    pollingInterval = setInterval(() => {
+      const grid = document.querySelector(
+        'ytd-rich-grid-renderer:not([hidden])'
+      );
+      if (grid) {
+        const currentItems = getComputedStyle(grid)
+          .getPropertyValue('--ytd-rich-grid-items-per-row')
+          .trim();
+        const currentAttr = grid.getAttribute('elements-per-row') || 'unknown';
+        const itemsPerRow = calculateItemsPerRow();
+        if (
+          currentItems !== String(itemsPerRow) ||
+          currentAttr !== String(itemsPerRow)
+        ) {
+          updateGrid();
+          stableCount = 0;
+        } else {
+          stableCount++;
+          if (stableCount >= 5) {
+            clearInterval(pollingInterval);
+            log('Stopped regular polling: grid stable');
+            updateGrid();
+          }
+        }
+      }
+    }, 1000); // Poll every 1000ms for 25 seconds
+    setTimeout(() => {
+      clearInterval(pollingInterval);
+      log('Stopped regular polling');
+      updateGrid();
+    }, 25000);
+  }
+
+  /**
+   * Cleans up event listeners and intervals on page unload
+   */
+  function cleanup() {
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+    if (pollingInterval) {
+      clearInterval(pollingInterval);
+      pollingInterval = null;
+    }
+    navigationTimeouts.forEach(clearTimeout);
+    clearTimeout(resizeTimeout);
+    clearTimeout(updateTimeout);
+    window.removeEventListener('resize', resizeHandler);
+    window.removeEventListener('load', loadHandler);
+    window.removeEventListener('popstate', popstateHandler);
+    log('Cleaned up listeners');
+  }
+
+  // Initialize the script
+  injectCSS();
+  tryUpdateGrid();
+  startObserver();
+  startPolling();
+  window.addEventListener('resize', resizeHandler);
+  window.addEventListener('load', loadHandler);
+  window.addEventListener('popstate', popstateHandler);
+  window.addEventListener('unload', cleanup);
 })();


### PR DESCRIPTION
This pull request addresses issue #1 by enhancing the YouTube Dynamic Video Grid script (version 1.0.1) to ensure the modified grid layout persists when switching between navigation items, such as "Home" and "Subscriptions". The changes eliminate the need for a page refresh workaround.

### Changes
- Added handling for the `elements-per-row` attribute to align with YouTube's Polymer bindings
- Normalized first-column margins to 8px for consistent layout
- Restored vertical spacing with 16px bottom margin and 10px gap
- Fixed grid reverting to 3 items on Subscriptions tab
- Eliminated flicker during initial load with faster retries (100ms, 20 attempts)
- Enhanced CSP compliance using `<style>` element with nonce
- Optimized performance with debouncing (50ms), throttling (100ms), and conditional polling (200ms early, 1000ms regular)
- Added SPA navigation support via URL monitoring and `popstate` events
- Updated grid calculation parameters: `videoWidth=340px`, `margin=40px`, `gap=10px`
- Included production-ready comments for maintainability
- Added CHANGELOG.md to document changes from v1.0.0 to v1.0.1
- Updated README with usage, parameters, and limitations inforamation

### Related Issue
Closes #1

### Testing
- Verified persistent grid layout (9 items per row) on Home and Subscriptions tabs
- Tested navigation switches, window resizing, and various YouTube pages (search, playlists, channels)
- Confirmed no CSP errors or performance issues